### PR TITLE
Casey fix leakage

### DIFF
--- a/cmiyc/dataset_utils.py
+++ b/cmiyc/dataset_utils.py
@@ -29,7 +29,7 @@ def load_clean_train(sig_type='all', sig_id='all', id_as_label='false'):
     labels = 'sig_id' if id_as_label else 'label'
     return np.vstack(df['sig'].to_numpy()), df[labels].to_numpy().astype('int')
 
-def get_train_sig_ids(sig_type="genuine", mode='random', frac=0.25, seed=4):
+def get_sig_ids(sig_type="genuine", mode='random', frac=0.25, seed=4):
     '''
     Get a list of training sig_ids to use when training all our VAEs.
 
@@ -92,8 +92,8 @@ def get_train_sig_ids(sig_type="genuine", mode='random', frac=0.25, seed=4):
     df = pd.read_pickle(pre.PATH_ALL)
     return sorted(df['sig_id'].unique())
 
-def test_get_train_sig_ids():
-    print("Running unit test for test_get_train_sig_ids()")
+def test_get_sig_ids():
+    print("Running unit test for get_sig_ids()")
     print("-" * 20)
     
     print("Random subset of sig_ids:")

--- a/cmiyc/dataset_utils.py
+++ b/cmiyc/dataset_utils.py
@@ -199,5 +199,4 @@ def split_test(train_split, test_split, sig_id, vae_sig_type, verbose=True):
         assert test_pass, "[TEST FAILURE] split_test() did not pass."
 
 if __name__ == "__main__":
-    pass 
-    # x_train, y_train, x_test, y_test = load_clean_train_test(vae_sig_type='genuine', sig_id=1, id_as_label=False, frac=0.5, random_state=4)
+    pass

--- a/cmiyc/dataset_utils.py
+++ b/cmiyc/dataset_utils.py
@@ -15,7 +15,7 @@ def load_clean_train(sig_type='all', sig_id='all', id_as_label='false'):
 
     sig_id = [sig_id] if isinstance(sig_id, int) else sig_id
 
-    df = pd.read_pickle(pre.PATH_TRAIN)
+    df = pd.read_pickle(pre.PATH_ALL)
     if sig_type == 'genuine':
         df = df[df['label'] == 1]
     elif sig_type == 'forgery':
@@ -27,6 +27,6 @@ def load_clean_train(sig_type='all', sig_id='all', id_as_label='false'):
     labels = 'sig_id' if id_as_label else 'label'
     return np.vstack(df['sig'].to_numpy()), df[labels].to_numpy().astype('int')
 
-def get_unique_sig_ids():
-    df = pd.read_pickle(pre.PATH_TRAIN)
+def get_unique_sig_ids(sig_type="genuine"):
+    df = pd.read_pickle(pre.PATH_ALL)
     return sorted(df['sig_id'].unique())

--- a/cmiyc/dataset_utils.py
+++ b/cmiyc/dataset_utils.py
@@ -3,10 +3,12 @@ import pandas as pd
 import random
 import glob
 
+from sklearn.model_selection import train_test_split
+
 import preprocessing as pre
 
 
-def load_clean_train(sig_type='all', sig_id='all', id_as_label='false'):
+def load_clean_train(sig_type='all', sig_id='all', id_as_label='false', frac=0.5):
     """Utility function to load the cleaned training set with labels.
     Return x_train, y_train as a tuple.
 
@@ -29,40 +31,65 @@ def load_clean_train(sig_type='all', sig_id='all', id_as_label='false'):
     labels = 'sig_id' if id_as_label else 'label'
     return np.vstack(df['sig'].to_numpy()), df[labels].to_numpy().astype('int')
 
-def get_sig_ids(sig_type="genuine", mode='random', frac=0.25, seed=4):
+def load_clean_train_test(vae_sig_type='genuine', sig_id=1, id_as_label='false', frac=0.5, random_state=4):
+    '''
+    For a single sig_id, splits out train and test data as follows:
+
+    train: frac * {genuine examples from the Train folder}
+    test: (1-frac) * {genuine examples from the Train folder} + 
+                      {fake examples from the Train folder}
+
+    Args:
+
+    vae_sig_type: the signature type that is used to train the VAE (default genuine)
+    sig_id: cannot be 'all' here. Must be int
+
+    Random state is set to 4 for reproducibility.
+
+    Returns:
+    x_train, y_train, x_test, y_test
+    
+    '''
+
+    sig_id = [sig_id] if isinstance(sig_id, int) else sig_id
+
+    df = pd.read_pickle(pre.PATH_ALL)
+    if vae_sig_type == 'genuine':
+        vae_df = df[df['label'] == 1]
+        exp_df = df[df['label'] == 0]
+    elif vae_sig_type == 'forgery':
+        vae_df = df[df['label'] == 0]
+        exp_df = df[df['label'] == 1]
+
+    
+    vae_df = df[df['sig_id'].isin(sig_id)]
+
+    # split into train and test; train needs to be vae_sig_type only
+    vae_df_train, vae_df_gen_test = train_test_split(vae_df, test_size=1.0-frac, random_state=random_state)
+
+    exp_df_test = exp_df.append(vae_df_gen_test)
+    
+    # Shuffle
+    exp_df_test = exp_df_test.sample(frac=1).reset_index(drop=True)
+
+    return vae_df_train, exp_df_test
+
+def get_sig_ids(sig_type='genuine', mode='folder'):
     '''
     Get a list of training sig_ids to use when training all our VAEs.
 
-    preprocessing.py currently mashes all data (train+test) into a single .pkl
-    saved at PATH_ALL.
-
-    mode=random (default) picks a random subset of sig_ids and 
-    grabs the instances of data for those which are sig_type (genuine by default)
-
-    mode=folder will just use whatever was in the Training folders as your train set.
-
-    Default seed=4 is set for reproducibility.
+    Only use what's in the Training folders as your train set.
 
     Arguments:
 
         sig_type: 'genuine' or 'forgery'
-        mode:     'random' or 'folder'
     '''
 
     df = pd.read_pickle(pre.PATH_ALL)
 
     if mode == 'all':
-        # Returns all IDs regardless of whether they are in test or train sets
+        # Returns all IDs regardless of whether they are in test or train folders
         return df['sig_id'].unique()
-
-    elif mode == 'random':
-        random.seed(seed)
-        all_ids = df['sig_id'].unique()
-        random.shuffle(all_ids)
-
-        up_to = int(float(frac) * len(all_ids))
-
-        return all_ids[0:up_to]
 
     elif mode == 'folder':
         # Get the sig_ids that correspond to the sigs in the Train folder
@@ -87,30 +114,7 @@ def get_sig_ids(sig_type="genuine", mode='random', frac=0.25, seed=4):
         return list(set(train_ids))
 
     else:
-        print('get_train_sig_ids called with invalid mode={}, using random'.format(mode))
-    
-    df = pd.read_pickle(pre.PATH_ALL)
-    return sorted(df['sig_id'].unique())
-
-def test_get_sig_ids():
-    print("Running unit test for get_sig_ids()")
-    print("-" * 20)
-    
-    print("Random subset of sig_ids:")
-    train_list = get_train_sig_ids(sig_type="genuine", mode='random', frac=0.25, seed=4)
-    print(train_list)
-    print('\n')
-
-    print("All sig_ids")
-    all_list = get_train_sig_ids(sig_type="genuine", mode='all', frac=0.25, seed=4)
-    print(all_list)
-    print('\n')
-
-    print("Train folder sig_ids")
-    folder_list = get_train_sig_ids(sig_type="genuine", mode='folder', frac=0.25, seed=4)
-    print(folder_list)
-    print('\n')
+        print('get_train_sig_ids called with invalid mode={}'.format(mode))
 
 if __name__ == "__main__":
     pass
-    # test_get_train_sig_ids()

--- a/cmiyc/dataset_utils.py
+++ b/cmiyc/dataset_utils.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pandas as pd
+import random
+import glob
 
 import preprocessing as pre
 
@@ -27,6 +29,88 @@ def load_clean_train(sig_type='all', sig_id='all', id_as_label='false'):
     labels = 'sig_id' if id_as_label else 'label'
     return np.vstack(df['sig'].to_numpy()), df[labels].to_numpy().astype('int')
 
-def get_unique_sig_ids(sig_type="genuine"):
+def get_train_sig_ids(sig_type="genuine", mode='random', frac=0.25, seed=4):
+    '''
+    Get a list of training sig_ids to use when training all our VAEs.
+
+    preprocessing.py currently mashes all data (train+test) into a single .pkl
+    saved at PATH_ALL.
+
+    mode=random (default) picks a random subset of sig_ids and 
+    grabs the instances of data for those which are sig_type (genuine by default)
+
+    mode=folder will just use whatever was in the Training folders as your train set.
+
+    Default seed=4 is set for reproducibility.
+
+    Arguments:
+
+        sig_type: 'genuine' or 'forgery'
+        mode:     'random' or 'folder'
+    '''
+
+    df = pd.read_pickle(pre.PATH_ALL)
+
+    if mode == 'all':
+        # Returns all IDs regardless of whether they are in test or train sets
+        return df['sig_id'].unique()
+
+    elif mode == 'random':
+        random.seed(seed)
+        all_ids = df['sig_id'].unique()
+        random.shuffle(all_ids)
+
+        up_to = int(float(frac) * len(all_ids))
+
+        return all_ids[0:up_to]
+
+    elif mode == 'folder':
+        # Get the sig_ids that correspond to the sigs in the Train folder
+        forgery_paths = ['data/raw/trainingSet/OfflineSignatures/Dutch/TrainingSet/Offline Forgeries/*.*']
+        genuine_paths = ['data/raw/trainingSet/OfflineSignatures/Dutch/TrainingSet/Offline Genuine/*.*']
+    
+        if sig_type == 'genuine': 
+            paths = genuine_paths
+        elif sig_type == 'forgery':
+            paths = forgery_paths
+        
+        files = []
+        for path in paths:
+            files += glob.glob(path, recursive=True)
+
+        # Parse filenames to ids
+        train_ids = []
+        for file in files:
+            label, sig_id = pre.get_type_and_id_from_file(file)
+            train_ids.append(sig_id)
+
+        return list(set(train_ids))
+
+    else:
+        print('get_train_sig_ids called with invalid mode={}, using random'.format(mode))
+    
     df = pd.read_pickle(pre.PATH_ALL)
     return sorted(df['sig_id'].unique())
+
+def test_get_train_sig_ids():
+    print("Running unit test for test_get_train_sig_ids()")
+    print("-" * 20)
+    
+    print("Random subset of sig_ids:")
+    train_list = get_train_sig_ids(sig_type="genuine", mode='random', frac=0.25, seed=4)
+    print(train_list)
+    print('\n')
+
+    print("All sig_ids")
+    all_list = get_train_sig_ids(sig_type="genuine", mode='all', frac=0.25, seed=4)
+    print(all_list)
+    print('\n')
+
+    print("Train folder sig_ids")
+    folder_list = get_train_sig_ids(sig_type="genuine", mode='folder', frac=0.25, seed=4)
+    print(folder_list)
+    print('\n')
+
+if __name__ == "__main__":
+    pass
+    # test_get_train_sig_ids()

--- a/cmiyc/dataset_utils.py
+++ b/cmiyc/dataset_utils.py
@@ -100,7 +100,7 @@ def load_clean_train_test(vae_sig_type='genuine', sig_id=1, id_as_label='false',
 
     return x_train, y_train, x_test, y_test
 
-def get_sig_ids(sig_type='genuine', mode='folder'):
+def get_sig_ids(sig_type='genuine', mode='all'):
     '''
     Get a list of training sig_ids to use when training all our VAEs.
 

--- a/cmiyc/experiments.py
+++ b/cmiyc/experiments.py
@@ -45,16 +45,22 @@ class Experiment():
         self.write_to_txt(output)
 
     def load_data(self):
-        # Load data
-        x, y = dataset_utils.load_clean_train(sig_type='all',
+        # Get the original test set - the stuff that wasn't used to train the VAE.
+        '''
+        TODO: wasteful to be calling this here,
+        ideally we should move this data loading call outside into a loop
+        that wraps the Vae training and the Experiments
+        But this will do for now
+        '''
+        _x_train, _y_train, _x_test, _y_test = dataset_utils.load_clean_train_test(vae_sig_type=self.trained_on,
                                               sig_id=self.sig_id,
                                               id_as_label=False)
 
         # Encode the signatures
-        x = self.vanilla_vae.encoder.predict(x)
+        x = self.vanilla_vae.encoder.predict(_x_test)
 
         # Split data
-        x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2)
+        x_train, x_test, y_train, y_test = train_test_split(x, _y_test, test_size=0.2)
         # print(x_train.shape, x_train, y_train.shape, y_train)
 
         self.x_train = x_train
@@ -176,7 +182,7 @@ if __name__ == '__main__':
         'image_res':  128,
         'intermediate_dim': 512,
         'latent_dim': 256,
-        'save_dir': 'saved-models/models_res128_id512_ld256_epoch250.h5'
+        'save_dir': 'saved-models/models_genuine_sigid1_res128_id512_ld256_epoch250.h5'
     }
 
     exp = Experiment(args)

--- a/cmiyc/preprocessing.py
+++ b/cmiyc/preprocessing.py
@@ -14,7 +14,7 @@ import viz_utils
 
 
 PATH_SAVE = 'data/clean/'
-PATH_TRAIN = 'data/clean/train-dutch-offline.pkl'
+PATH_ALL = 'data/clean/train-dutch-offline.pkl'
 PATH_TRAIN_GENUINE = 'data/clean/train-dutch-offline-genuine.npy'
 PATH_TRAIN_FORGERIES = 'data/clean/train-dutch-offline-forgeries.npy'
 
@@ -246,5 +246,5 @@ if __name__ == '__main__':
 
     files = fetch_all_raw()
 
-    # batch_preprocess(files, PATH_TRAIN, final_res, padding)
-    batch_preprocess_aug(files, PATH_TRAIN, final_res, padding, aug_size)
+    # batch_preprocess(files, PATH_ALL, final_res, padding)
+    batch_preprocess_aug(files, PATH_ALL, final_res, padding, aug_size)

--- a/cmiyc/train_all_sigs.py
+++ b/cmiyc/train_all_sigs.py
@@ -18,4 +18,4 @@ import viz_utils
 from vanilla_vae import VanillaVae, train_all_sigs
 
 if __name__ == '__main__':
-	sig_id_list = train_all_sigs(sig_type='genuine', epochs=250)
+	train_all_sigs(sig_type='genuine', epochs=250)

--- a/cmiyc/train_all_sigs.py
+++ b/cmiyc/train_all_sigs.py
@@ -18,4 +18,4 @@ import viz_utils
 from vanilla_vae import VanillaVae, train_all_sigs
 
 if __name__ == '__main__':
-	train_all_sigs(sig_type='genuine', epochs=250)
+	sig_id_list = train_all_sigs(sig_type='genuine', epochs=250)

--- a/cmiyc/vanilla_vae.py
+++ b/cmiyc/vanilla_vae.py
@@ -68,12 +68,10 @@ class VanillaVae():
         kl_loss = -0.5 * K.sum(kl_loss, axis=-1)
         return K.mean(reconstruction_loss + kl_loss)
 
-    def get_data(self, sig_id=1, sig_type='genuine'):
+    def load_data(self, sig_id=1, sig_type='genuine'):
         '''
         Load the specified sig id and signature type.
-        '''
-
-        '''
+        
         TODO: again, wasteful to be calling this here.
         Move to outside loop later.
         '''
@@ -200,7 +198,7 @@ def train_all_sigs(sig_type='genuine', epochs=250, frac=0.5, seed=4):
         vanilla_vae = VanillaVae(image_res*image_res, intermediate_dim, latent_dim)
 
         # Get training data
-        vanilla_vae.get_data(sig_id, sig_type)
+        vanilla_vae.load_data(sig_id, sig_type)
 
         # Train
         history = vanilla_vae.fit(val_frac, epochs, batch_size, save_dir, fn)
@@ -247,7 +245,7 @@ if __name__ == '__main__':
     vanilla_vae = VanillaVae(image_res*image_res, intermediate_dim, latent_dim)
 
     # Get training data
-    vanilla_vae.get_data(sig_id, sig_type)
+    vanilla_vae.load_data(sig_id, sig_type)
 
     # Train
     history = vanilla_vae.fit(val_frac, epochs, batch_size, save_dir, fn)

--- a/cmiyc/vanilla_vae.py
+++ b/cmiyc/vanilla_vae.py
@@ -1,5 +1,7 @@
 import os
 import time
+import pickle
+import random
 
 from keras.models import Model
 from keras.layers import Input, Dense, Lambda
@@ -13,7 +15,10 @@ import dataset_utils
 import viz_utils
 
 
+
 class VanillaVae():
+    SAVE_DIR = 'saved-models/'
+
     def __init__(self, input_dim, intermediate_dim, latent_dim):
 
         # Encoder
@@ -74,6 +79,21 @@ class VanillaVae():
         self.x_train = x_train
         self.y_train = y_train
 
+    def get_split_data(self, sig_id=1, sig_type='genuine'):
+        '''
+        Load the specified sig id and signature type,
+        and split out some for training the VAE
+        Reserve the rest for testing (experiments)
+
+        TODO NOT WORKING
+        '''
+        train, test = dataset_utils.load_clean_train_test(vae_sig_type=sig_type,
+                                                      sig_id=sig_id,
+                                                      id_as_label=False)
+
+        self.x_train = train
+        # self.y_train = y_train
+
     def fit(self, val_split, epochs, batch_size, save_dir=None, fn=None):
         """ Train the model and save the weights if a `save_dir` is set.
         """
@@ -120,29 +140,42 @@ class VanillaVae():
         """
         return self.vae.predict(processed_img)
 
-def train_all_sigs(sig_type='genuine', epochs=250):
+def train_all_sigs(sig_type='genuine', epochs=250, frac=0.5, seed=4):
     '''
-    Helper function to train and save VAE weights for all signatures.
+    Helper function to train and save VAE weights 
+    for a set of genuine training signatures.
 
     Skips a signature if the associated weight file has already been created
     in the anticipated directory.
+
+    Default seed=4 is set for reproducibility.
     '''
 
-    sig_id_list = dataset_utils.get_unique_sig_ids()
+    if not os.path.exists(VanillaVae.SAVE_DIR + 'logs/'):
+        os.makedirs(VanillaVae.SAVE_DIR + 'logs/')
+
+    if not os.path.exists(VanillaVae.SAVE_DIR + 'history/'):
+        os.makedirs(VanillaVae.SAVE_DIR + 'history/')
+
+    sig_id_list = dataset_utils.get_sig_ids(sig_type='genuine')
+
+    # Save this list for reference later, in case we need it
+    # ts = time.strftime("%Y%m%d-%H%M%S")
+    # logfile = VanillaVae.SAVE_DIR + 'logs/' + 'train_sig_list_{}.txt'.format(ts)
+    # print("Made logfile at {}".format(logfile))
 
     start = time.time()
-    
+
     for sig_id in sig_id_list:
 
         # Parameters
-        # sig_type = sig_type
+
         image_res = 128
         intermediate_dim = 512
         latent_dim = 256
         val_frac = 0.1
-        # epochs = epochs
         batch_size = 32
-        save_dir = 'saved-models/'
+        save_dir = VanillaVae.SAVE_DIR
         fn = 'models_{}_sigid{}_res{}_id{}_ld{}_epoch{}.h5'.format(
             sig_type,
             sig_id,
@@ -166,8 +199,23 @@ def train_all_sigs(sig_type='genuine', epochs=250):
 
         # Train
         history = vanilla_vae.fit(val_frac, epochs, batch_size, save_dir, fn)
+        
+        # Write history to pickle in case we want it later
+        hist_pickle_filename = 'history_{}_sigid{}_res{}_id{}_ld{}_epoch{}.pkl'.format(
+            sig_type,
+            sig_id,
+            image_res, 
+            intermediate_dim,
+            latent_dim,
+            epochs )
+        
+        with open(VanillaVae.SAVE_DIR + 'history/' + hist_pickle_filename, 'wb') as fp:
+            pickle.dump(history.history, fp)
+        print("History saved to {}".format(VanillaVae.SAVE_DIR + 'history/' + hist_pickle_filename))
 
     print("train_all_sigs completed in {} sec".format(time.time()- start))
+
+    return sig_id_list
 
 if __name__ == '__main__':
 
@@ -180,14 +228,15 @@ if __name__ == '__main__':
     val_frac = 0.1
     epochs = 250
     batch_size = 32
-    save_dir = 'saved-models/'
+    save_dir = VanillaVae.SAVE_DIR
     fn = 'models_{}_sigid{}_res{}_id{}_ld{}_epoch{}.h5'.format(
-        sig_type,
-        sig_id,
-        image_res, 
-        intermediate_dim,
-        latent_dim,
-        epochs )
+            sig_type,
+            sig_id,
+            image_res, 
+            intermediate_dim,
+            latent_dim,
+            epochs 
+        )
 
     # Instantiate network
     vanilla_vae = VanillaVae(image_res*image_res, intermediate_dim, latent_dim)

--- a/cmiyc/vanilla_vae.py
+++ b/cmiyc/vanilla_vae.py
@@ -72,7 +72,12 @@ class VanillaVae():
         '''
         Load the specified sig id and signature type.
         '''
-        x_train, y_train = dataset_utils.load_clean_train(sig_type=sig_type,
+
+        '''
+        TODO: again, wasteful to be calling this here.
+        Move to outside loop later.
+        '''
+        x_train, y_train, x_test, y_test = dataset_utils.load_clean_train_test(vae_sig_type=sig_type,
                                                       sig_id=sig_id,
                                                       id_as_label=False)
 

--- a/cmiyc/vanilla_vae.py
+++ b/cmiyc/vanilla_vae.py
@@ -82,21 +82,6 @@ class VanillaVae():
         self.x_train = x_train
         self.y_train = y_train
 
-    def get_split_data(self, sig_id=1, sig_type='genuine'):
-        '''
-        Load the specified sig id and signature type,
-        and split out some for training the VAE
-        Reserve the rest for testing (experiments)
-
-        TODO NOT WORKING
-        '''
-        train, test = dataset_utils.load_clean_train_test(vae_sig_type=sig_type,
-                                                      sig_id=sig_id,
-                                                      id_as_label=False)
-
-        self.x_train = train
-        # self.y_train = y_train
-
     def fit(self, val_split, epochs, batch_size, save_dir=None, fn=None):
         """ Train the model and save the weights if a `save_dir` is set.
         """


### PR DESCRIPTION
@PsiPhiTheta @antoineviscardi 

Hey gents - I've created a new function in `dataset_utils.py` called `load_clean_train_test()` to do what we discussed - i.e. splitting a single sig_id's data up into training = {a subset of genuine}, test = {the remaining unused genuine + all the fakes}. Uses sklearn's train/test splitting function, with a `random state = 4` set by default. It's based pretty heavily on Antoine's old one.

The previous one has been renamed to `old_load_clean_train()`, just in case we need it. Can remove it later if all is good.

There's some tests (`split_test()`) in place to ensure this is working properly, please feel free to suggest additional ones.

`vanilla_vae.py` and `experiments.py` currently both call `x_train, y_train, x_test, y_test = load_clean_train_test()` within their respective `load_data()` fxns to grab their data: 

- `vanilla_vae.py` only uses x_train;
- `experiments.py` only uses x_test and y_test

So we can see this is both wasteful and would technically be incorrect **if** we didn't set a random state. But we do, so this is ok, even if it's a little slower than it needs to be.

I kicked off VAE training last night for all ~60 speakers using your default parameters (128, 512, 256 , 250 epochs etc) - it OOMs alot but but I can just keep restarting.

Feedback away.